### PR TITLE
Feature/update form fields part 2 #37

### DIFF
--- a/pattern-library/src/colors/index.css
+++ b/pattern-library/src/colors/index.css
@@ -268,6 +268,7 @@
 @value coral-lighter-8-saturated: #e72914;
 @value red: #c00404;
 @value red-lighter-90: #f8e6e6;
+@value red-lighter-80: #f2cccc;
 @value green: #1ca420;
 @value green-lighter-90: #e8f6e9;
 @value green-lighter-80: #d1ecd2;

--- a/pattern-library/src/colors/index.css
+++ b/pattern-library/src/colors/index.css
@@ -4,6 +4,7 @@
  * Grayscale *
  *************/
 @value white: #ffffff;
+@value gray-10: #fafafa;
 @value background-gray-9: #f4f4f4;
 @value background-gray-8: #e5e5e5;
 @value safe-gray-7: #cccccc;

--- a/pattern-library/src/fields/css/shared/borders.css
+++ b/pattern-library/src/fields/css/shared/borders.css
@@ -1,14 +1,14 @@
 @value (
   black,
+  gray-10,
+  background-gray-9,
   coral-lighter-80,
   red-lighter-90
 ) from '@xo-union/colors';
 
-@value ( gray-1, gray-2 ) from './colors';
-
 /* Borders */
 @value solid-border: 1px solid;
 @value black-border: solid-border black;
-@value gray-1-border: solid-border gray-1;
-@value gray-2-border: solid-border gray-2;
+@value gray-10-border: solid-border gray-10;
+@value gray-9-border: solid-border background-gray-9;
 @value red-border: solid-border red-lighter-90;

--- a/pattern-library/src/fields/css/shared/colors.css
+++ b/pattern-library/src/fields/css/shared/colors.css
@@ -1,4 +1,0 @@
-/* Grayscale */
-@value gray-1: #fafafa;
-@value gray-2: #f4f4f4;
-@value gray-3: #cfcfcf;

--- a/pattern-library/src/fields/css/styles/dropdown-field.scss
+++ b/pattern-library/src/fields/css/styles/dropdown-field.scss
@@ -32,8 +32,8 @@
   position: absolute;
   right: 0;
   top: 0;
-  margin-top: 15px;
-  margin-right: spacer-x;
+  margin-top: 1rem;
+  margin-right: 1rem;
 }
 
 .dropdown-list {

--- a/pattern-library/src/fields/css/styles/field-base.scss
+++ b/pattern-library/src/fields/css/styles/field-base.scss
@@ -1,11 +1,11 @@
-@value ( gray-2-border, gray-1-border, black-border ) from '#/fields/css/shared/borders';
-@value ( gray-1 ) from '#/fields/css/shared/colors';
+@value ( gray-9-border, gray-10-border, black-border ) from '#/fields/css/shared/borders';
+@value ( gray-10 ) from '@xo-union/colors';
 @value ( font-up-1 ) from '@xo-union/typography/sizes';
 
 .field-base {
   font-size: font-up-1;
   -webkit-appearance: none;
-  border: gray-2-border;
+  border: gray-9-border;
   // Fix firefox render error
   box-shadow: none;
   width: 100%;
@@ -19,8 +19,8 @@
   }
 
   &:disabled {
-    background: gray-1;
-    border: gray-1-border;
+    background-color: gray-10;
+    border: gray-10-border;
   }
 }
 

--- a/pattern-library/src/fields/css/styles/field.scss
+++ b/pattern-library/src/fields/css/styles/field.scss
@@ -3,10 +3,9 @@
   red-lighter-90,
   white,
   safe-gray-7,
-  gray-4,
+  gray-6,
   black,
-  green-lighter-80,
-  green-lighter-90
+  green-lighter-80
 ) from '@xo-union/colors';
 
 @value ( red-border ) from '#/fields/css/shared/borders';
@@ -20,21 +19,18 @@
 
 .field {
   composes: field-base from '#/fields/css/styles/field-base';
-  padding: 20px spacer-x 4px spacer-x;
+  padding: 15px .5rem spacer-x;
 
   &:not(:placeholder-shown) ~ .field-label,
   &:focus ~ .field-label {
     font-size: font-down-4;
     margin-top: 6px;
+    color: black;
   }
 
   &:disabled ~ .field-label {
     color: safe-gray-7;
     text-decoration: line-through;
-  }
-
-  &:focus ~ .field-label {
-    color: black;
   }
 }
 
@@ -50,7 +46,8 @@
 
 .valid-field {
   composes: field;
-  background-color: green-lighter-90;
+  background-color: green-lighter-80;
+  border-color: green-lighter-80 !important;
 }
 
 .requirements {
@@ -73,9 +70,9 @@
   composes: label from '#/fields/css/styles/label';
 
   font-size: font-up-1;
-  margin-left: 10px;
-  margin-top: 14px;
-  color: gray-4;
+  margin-left: .5rem;
+  margin-top: 13px;
+  color: gray-6;
   transition: all 0.2s ease-out;
 }
 

--- a/pattern-library/src/fields/css/styles/field.scss
+++ b/pattern-library/src/fields/css/styles/field.scss
@@ -2,6 +2,7 @@
   red,
   red-lighter-90,
   white,
+  safe-gray-7,
   gray-4,
   black,
   green-lighter-80,
@@ -28,7 +29,7 @@
   }
 
   &:disabled ~ .field-label {
-    color: gray-3;
+    color: safe-gray-7;
     text-decoration: line-through;
   }
 

--- a/pattern-library/src/fields/css/styles/textarea.scss
+++ b/pattern-library/src/fields/css/styles/textarea.scss
@@ -1,4 +1,4 @@
-@value ( black, gray-4 ) from '@xo-union/colors';
+@value ( black, gray-6 ) from '@xo-union/colors';
 @value ( spacer-x ) from '#/fields/css/shared/spacing';
 @value ( font-up-1 ) from '@xo-union/typography/sizes';
 
@@ -10,10 +10,16 @@
   color: black;
   resize: none;
 
-  &::-moz-placeholder,
-  &::-ms-input-placeholder,
+  &::placeholder {
+    color: gray-6;
+    font-size: font-up-1;
+  }
+  &::-ms-input-placeholder {
+    color: gray-6;
+    font-size: font-up-1;
+  }
   &::-webkit-input-placeholder {
-    color: gray-4;
+    color: gray-6;
     font-size: font-up-1;
   }
 }
@@ -35,4 +41,5 @@
 
   margin-left: 10px;
   margin-top: 10px;
+  color: black;
 }

--- a/pattern-library/src/fields/css/themes.scss
+++ b/pattern-library/src/fields/css/themes.scss
@@ -1,5 +1,4 @@
-@value ( gray-2 ) from '#/fields/css/shared/colors';
-@value ( background-gray-9, background-gray-8, white ) from '@xo-union/colors';
+@value ( gray-10, background-gray-9, background-gray-8, white ) from '@xo-union/colors';
 
 @mixin theme($base, $accent) {
   .field,
@@ -10,6 +9,10 @@
   .textarea-label
   {
     background-color: $base;
+
+    &:disabled {
+      background-color: gray-10;
+    }
   }
 
   .dropdown-item-is-selected {
@@ -46,7 +49,7 @@
 }
 
 .gray-theme {
-  @include theme(gray-2, background-gray-8);
+  @include theme(background-gray-9, background-gray-8);
 }
 
 .white-theme {

--- a/pattern-library/src/fields/css/themes.scss
+++ b/pattern-library/src/fields/css/themes.scss
@@ -1,4 +1,9 @@
-@value ( gray-10, background-gray-9, background-gray-8, white ) from '@xo-union/colors';
+@value (
+  gray-10,
+  background-gray-9,
+  background-gray-8,
+  white
+) from '@xo-union/colors';
 
 @mixin theme($base, $accent) {
   .field,


### PR DESCRIPTION
- Add new gray color `gray-10: #fafafa;` for disable input bg
- Update form field colors and spacing
- Remove fields/css/shared/colors.css
- Break out `.textarea::placeholder` selector since webkit needs its selector to be on one line