### PR TITLE
Fix linting warnings [Closes #60]

### DIFF
--- a/.eslintrc.jasmine.js
+++ b/.eslintrc.jasmine.js
@@ -15,6 +15,8 @@ module.exports = {
      * See this:
      * https://gist.github.com/traviskaufman/11131303
      **/
-    'func-names': 'off'
+    'func-names': 'off',
+    'jasmine/no-spec-dupes': [1, 'branch'],
+    'jasmine/no-suite-dupes': [1, 'branch']
   }
 };

--- a/scripts/helpers/diff/logDiffTree.js
+++ b/scripts/helpers/diff/logDiffTree.js
@@ -55,9 +55,11 @@ module.exports = async function logDiffTree() {
   .then(createDiffTreeObject)
   .then(renderTree)
   .then((changedPackages) => {
+    /* eslint-disable */
     console.log('These are changed files since the last publish');
     console.log(`Using tag ${chalk.green(tag)}`);
     console.log(EOL);
     console.log(changedPackages);
+    /* eslint-enable */
   });
 };

--- a/scripts/helpers/diff/parseDiff.js
+++ b/scripts/helpers/diff/parseDiff.js
@@ -69,11 +69,10 @@ module.exports = function parseDiff(diffString) {
   });
 };
 
-module.exports.withColors = function (diffString) {
+module.exports.withColors = function withColors(diffString) {
   return module.exports(diffString).map(({ typeOfChange, name }) => {
     const color = diffStatusColorRules(typeOfChange);
 
     return { name, typeOfChange: new ColoredString(typeOfChange, color) };
   });
 };
-


### PR DESCRIPTION
- Tweak linting rules for:
  - `jasmine/no-spec-dupes`
  - `jasmine/no-suite-dupes`
- ESLint disable for console.log output warnings
- Add function name to `module.exports` fn